### PR TITLE
binary is renamed back to atecc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.o
-atecc-util
+atecc
 .*.swp
 *.txt
 *.bin

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ CFLAGS += $(addprefix -I, $(INCLUDE) $(TEST_INCLUDE)) $(addprefix -D,$(OPTIONS))
 # Regardless of platform set the vpath correctly
 vpath %.c $(call BACK2SLASH,$(sort $(dir $(SOURCES) $(TEST_SOURCES))))
 
-TARGET=atecc-util
+TARGET=atecc
 OBJS=atecc.o \
 	 atecc-init.o \
 	 atecc-config.o \

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ atecc-util consists of set of distinct tools called commands. Each command have 
 
 Multiple commands can be specified at once as following:
 
-    atecc-util -b 10 -c 'serial' -c 'read-config /tmp/config.dump'
+    atecc -b 10 -c 'serial' -c 'read-config /tmp/config.dump'
 
 ## Installation
 
@@ -55,7 +55,7 @@ You can build Debian package as usual:
 
 Reads ATECCx08 IC serial number in hex format:
 ```
-$ ./atecc-util -b 10 -c 'serial'
+$ ./atecc -b 10 -c 'serial'
 012355b52d66a109ee
 ```
 


### PR DESCRIPTION
this doesn't affect debian package build